### PR TITLE
Add detailed README with environment variable instructions and usage examples

### DIFF
--- a/DotNetConfig.csproj
+++ b/DotNetConfig.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/Myservice.cs
+++ b/Myservice.cs
@@ -1,0 +1,18 @@
+namespace DotNetConfig;
+
+
+public class MyService
+{
+    private readonly IConfiguration _configuration;
+
+    public MyService(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public string GetMessage()
+    {
+        return _configuration["AppSettings:Message"];
+    }
+}
+

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,22 @@
+using DotNetConfig;
+
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Configuration
+    .SetBasePath(Directory.GetCurrentDirectory())
+    .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+    .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true)
+    .AddEnvironmentVariables();
+
+Console.WriteLine($"Environment: {builder.Environment.EnvironmentName}");
+
+builder.Services.AddSingleton<MyService>();
+
 var app = builder.Build();
 
-app.MapGet("/", () => "Hello World!");
+app.MapGet("/", (MyService service) =>
+{
+    return Results.Ok(service.GetMessage());
+});
 
 app.Run();

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5249",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7107;http://localhost:5249",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ To run the application with a specific environment and load the corresponding `a
 
 ```sh
 set ASPNETCORE_ENVIRONMENT=Testing
-dotnet run --project DotNetConfig
+dotnet run --no-launch-profile
 ```
 
 ### Windows (PowerShell)
 
 ```sh
 $env:ASPNETCORE_ENVIRONMENT="Testing"
-dotnet run --project DotNetConfig
+dotnet run --no-launch-profile
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
 # DotNetConfig
+
+This project demonstrates how to load multiple `appsettings` files in an ASP.NET Core application based on the environment (e.g., Development, Testing).
+
+## How it works
+
+- The application loads:
+  - `appsettings.json` (always)
+  - `appsettings.{Environment}.json` (if present, e.g., `appsettings.Development.json`, `appsettings.Testing.json`)
+- The environment is determined by the `ASPNETCORE_ENVIRONMENT` variable.
+
+## Running with a specific environment
+
+To run the application with a specific environment and load the corresponding `appsettings.{Environment}.json` file, set the `ASPNETCORE_ENVIRONMENT` variable before running the app.
+
+### Windows (Command Prompt)
+
+```sh
+set ASPNETCORE_ENVIRONMENT=Testing
+dotnet run --project DotNetConfig
+```
+
+### Windows (PowerShell)
+
+```sh
+$env:ASPNETCORE_ENVIRONMENT="Testing"
+dotnet run --project DotNetConfig
+```
+
+
+
+## Example
+
+When running with `ASPNETCORE_ENVIRONMENT=Testing`, the API root (`/`) will return:
+
+```
+This is from TESTING appsettings.Testing.json
+```
+
+When running with `ASPNETCORE_ENVIRONMENT=Development`, it will return:
+
+```
+This is from DEVELOPMENT appsettings.Development.json
+```
+
+## Project Structure
+
+- `appsettings.json` - Base configuration
+- `appsettings.Development.json` - Development-specific settings
+- `appsettings.Testing.json` - Testing-specific settings
+- `Program.cs` - Loads configuration based on environment
+
+---

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -1,8 +1,13 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+    
+        "AppSettings": {
+            "Message": "This is from DEVELOPMENT appsettings.Development.json"
+        }
+
     }
-  }
-}

--- a/appsettings.Testing.json
+++ b/appsettings.Testing.json
@@ -1,0 +1,13 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+
+    "AppSettings": {
+        "Message": "This is from TESTING appsettings.Testing.json"
+    }
+
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/obj/DotNetConfig.csproj.nuget.dgspec.json
+++ b/obj/DotNetConfig.csproj.nuget.dgspec.json
@@ -1,0 +1,76 @@
+{
+  "format": 1,
+  "restore": {
+    "C:\\Users\\NONSTOP\\source\\repos\\DotNetConfig\\DotNetConfig\\DotNetConfig.csproj": {}
+  },
+  "projects": {
+    "C:\\Users\\NONSTOP\\source\\repos\\DotNetConfig\\DotNetConfig\\DotNetConfig.csproj": {
+      "version": "1.0.0",
+      "restore": {
+        "projectUniqueName": "C:\\Users\\NONSTOP\\source\\repos\\DotNetConfig\\DotNetConfig\\DotNetConfig.csproj",
+        "projectName": "DotNetConfig",
+        "projectPath": "C:\\Users\\NONSTOP\\source\\repos\\DotNetConfig\\DotNetConfig\\DotNetConfig.csproj",
+        "packagesPath": "C:\\Users\\NONSTOP\\.nuget\\packages\\",
+        "outputPath": "C:\\Users\\NONSTOP\\source\\repos\\DotNetConfig\\DotNetConfig\\obj\\",
+        "projectStyle": "PackageReference",
+        "fallbackFolders": [
+          "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+        ],
+        "configFilePaths": [
+          "C:\\Users\\NONSTOP\\AppData\\Roaming\\NuGet\\NuGet.Config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+        ],
+        "originalTargetFrameworks": [
+          "net9.0"
+        ],
+        "sources": {
+          "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+          "https://api.nuget.org/v3/index.json": {}
+        },
+        "frameworks": {
+          "net9.0": {
+            "targetAlias": "net9.0",
+            "projectReferences": {}
+          }
+        },
+        "warningProperties": {
+          "warnAsError": [
+            "NU1605"
+          ]
+        },
+        "restoreAuditProperties": {
+          "enableAudit": "true",
+          "auditLevel": "low",
+          "auditMode": "direct"
+        },
+        "SdkAnalysisLevel": "9.0.200"
+      },
+      "frameworks": {
+        "net9.0": {
+          "targetAlias": "net9.0",
+          "imports": [
+            "net461",
+            "net462",
+            "net47",
+            "net471",
+            "net472",
+            "net48",
+            "net481"
+          ],
+          "assetTargetFallback": true,
+          "warn": true,
+          "frameworkReferences": {
+            "Microsoft.AspNetCore.App": {
+              "privateAssets": "none"
+            },
+            "Microsoft.NETCore.App": {
+              "privateAssets": "all"
+            }
+          },
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\9.0.203/PortableRuntimeIdentifierGraph.json"
+        }
+      }
+    }
+  }
+}

--- a/obj/DotNetConfig.csproj.nuget.g.props
+++ b/obj/DotNetConfig.csproj.nuget.g.props
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
+    <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
+    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">$(MSBuildThisFileDirectory)project.assets.json</ProjectAssetsFile>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
+    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">C:\Users\NONSTOP\.nuget\packages\;C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages</NuGetPackageFolders>
+    <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">PackageReference</NuGetProjectStyle>
+    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">6.13.2</NuGetToolVersion>
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <SourceRoot Include="C:\Users\NONSTOP\.nuget\packages\" />
+    <SourceRoot Include="C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages\" />
+  </ItemGroup>
+</Project>

--- a/obj/DotNetConfig.csproj.nuget.g.targets
+++ b/obj/DotNetConfig.csproj.nuget.g.targets
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />

--- a/obj/project.assets.json
+++ b/obj/project.assets.json
@@ -1,0 +1,82 @@
+{
+  "version": 3,
+  "targets": {
+    "net9.0": {}
+  },
+  "libraries": {},
+  "projectFileDependencyGroups": {
+    "net9.0": []
+  },
+  "packageFolders": {
+    "C:\\Users\\NONSTOP\\.nuget\\packages\\": {},
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages": {}
+  },
+  "project": {
+    "version": "1.0.0",
+    "restore": {
+      "projectUniqueName": "C:\\Users\\NONSTOP\\source\\repos\\DotNetConfig\\DotNetConfig\\DotNetConfig.csproj",
+      "projectName": "DotNetConfig",
+      "projectPath": "C:\\Users\\NONSTOP\\source\\repos\\DotNetConfig\\DotNetConfig\\DotNetConfig.csproj",
+      "packagesPath": "C:\\Users\\NONSTOP\\.nuget\\packages\\",
+      "outputPath": "C:\\Users\\NONSTOP\\source\\repos\\DotNetConfig\\DotNetConfig\\obj\\",
+      "projectStyle": "PackageReference",
+      "fallbackFolders": [
+        "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+      ],
+      "configFilePaths": [
+        "C:\\Users\\NONSTOP\\AppData\\Roaming\\NuGet\\NuGet.Config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+      ],
+      "originalTargetFrameworks": [
+        "net9.0"
+      ],
+      "sources": {
+        "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+        "https://api.nuget.org/v3/index.json": {}
+      },
+      "frameworks": {
+        "net9.0": {
+          "targetAlias": "net9.0",
+          "projectReferences": {}
+        }
+      },
+      "warningProperties": {
+        "warnAsError": [
+          "NU1605"
+        ]
+      },
+      "restoreAuditProperties": {
+        "enableAudit": "true",
+        "auditLevel": "low",
+        "auditMode": "direct"
+      },
+      "SdkAnalysisLevel": "9.0.200"
+    },
+    "frameworks": {
+      "net9.0": {
+        "targetAlias": "net9.0",
+        "imports": [
+          "net461",
+          "net462",
+          "net47",
+          "net471",
+          "net472",
+          "net48",
+          "net481"
+        ],
+        "assetTargetFallback": true,
+        "warn": true,
+        "frameworkReferences": {
+          "Microsoft.AspNetCore.App": {
+            "privateAssets": "none"
+          },
+          "Microsoft.NETCore.App": {
+            "privateAssets": "all"
+          }
+        },
+        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\9.0.203/PortableRuntimeIdentifierGraph.json"
+      }
+    }
+  }
+}

--- a/obj/project.nuget.cache
+++ b/obj/project.nuget.cache
@@ -1,0 +1,8 @@
+{
+  "version": 2,
+  "dgSpecHash": "oPdYyZ6DEzU=",
+  "success": true,
+  "projectFilePath": "C:\\Users\\NONSTOP\\source\\repos\\DotNetConfig\\DotNetConfig\\DotNetConfig.csproj",
+  "expectedPackageFiles": [],
+  "logs": []
+}


### PR DESCRIPTION
This PR introduces support for loading multiple appsettings files based on the environment in an ASP.NET Core application. It also adds clear documentation on how to run the application with different environments and what output to expect.

Key Changes
Configuration Loading:
The application now loads appsettings.json and, if present, appsettings.{Environment}.json (e.g., appsettings.Development.json, appsettings.Testing.json) based on the ASPNETCORE_ENVIRONMENT variable.
Service Registration:
MyService is registered as a singleton and retrieves messages from the configuration.
Minimal API Endpoint:
The root endpoint (/) returns the message from the current environment's configuration.